### PR TITLE
POSTYC-58: Sets the current language as language code for orders.

### DIFF
--- a/yellowcube.client.inc
+++ b/yellowcube.client.inc
@@ -268,7 +268,7 @@ function yellowcube_client_add_order(array $ship_addr, array $yc_product, stdCla
     ->setZIPCode($ship_addr['postal_code'])
     ->setCity($ship_addr['locality'])
     ->setEmail($order->mail)
-    ->setLanguageCode('en');
+    ->setLanguageCode($GLOBALS['language']->language);
 
   $yc_order = new Order();
   $yc_order


### PR DESCRIPTION
Unfortunately there is no user language setting associated with the order
or any order related entities. For now setting it to the site language
works for single language sites.
