### PR TITLE
POSTYC-62: Adds the shipping ui as dependency.

### DIFF
--- a/yellowcube.info
+++ b/yellowcube.info
@@ -4,6 +4,7 @@ core = 7.x
 package = Commerce
 dependencies[] = commerce
 dependencies[] = commerce_shipping
+dependencies[] = commerce_shipping_ui
 dependencies[] = commerce_message
 dependencies[] = commerce_stock
 dependencies[] = commerce_ss

--- a/yellowcube.module
+++ b/yellowcube.module
@@ -14,8 +14,8 @@ function yellowcube_menu() {
   $items = array();
 
   $items['admin/commerce/config/shipping/services/yellowcube/add'] = array(
-    'title' => 'Add a yellowcube shipping service',
-    'description' => 'Create a new yellowcube shipping service, including a title and base shipping rate.',
+    'title' => 'Add a YellowCube shipping service',
+    'description' => 'Create a new YellowCube shipping service, including a title and base shipping rate.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('yellowcube_shipping_service_form', yellowcube_commerce_shipping_service_new()),
     'access arguments' => array('administer shipping'),


### PR DESCRIPTION
When adding menu items like adding shipping services without
the shipping ui module present, those menu items are shown
on the Store -> Configuration page.
